### PR TITLE
Add optional start & end params to revalidation

### DIFF
--- a/src/main/kotlin/io/github/stscoundrel/revalidator/controller/RevalidateController.kt
+++ b/src/main/kotlin/io/github/stscoundrel/revalidator/controller/RevalidateController.kt
@@ -5,6 +5,7 @@ import io.github.stscoundrel.revalidator.service.RevalidatorService
 import kotlinx.coroutines.*
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 
@@ -15,26 +16,38 @@ data class RevalidationResponse(val statuses: Map<DictionaryType, Boolean>)
 class RevalidateController(val revalidatorService: RevalidatorService) {
 
     @GetMapping("/old-norse")
-    fun oldNorse(): RevalidationResponse {
-        revalidatorService.revalidateOldNorse()
+    fun oldNorse(
+        @RequestParam("start") start: Int? = null,
+        @RequestParam("end") end: Int? = null
+    ): RevalidationResponse {
+        revalidatorService.revalidateOldNorse(start, end)
         return RevalidationResponse(mapOf(DictionaryType.OLD_NORSE to true))
     }
 
     @GetMapping("/old-icelandic")
-    fun oldIcelandic(): RevalidationResponse {
-        revalidatorService.revalidateOldIcelandic()
+    fun oldIcelandic(
+        @RequestParam("start") start: Int? = null,
+        @RequestParam("end") end: Int? = null
+    ): RevalidationResponse {
+        revalidatorService.revalidateOldIcelandic(start, end)
         return RevalidationResponse(mapOf(DictionaryType.OLD_ICELANDIC to true))
     }
 
     @GetMapping("/old-swedish")
-    fun oldSwedish(): RevalidationResponse {
-        revalidatorService.revalidateOldSwedish()
+    fun oldSwedish(
+        @RequestParam("start") start: Int? = null,
+        @RequestParam("end") end: Int? = null
+    ): RevalidationResponse {
+        revalidatorService.revalidateOldSwedish(start, end)
         return RevalidationResponse(mapOf(DictionaryType.OLD_SWEDISH to true))
     }
 
     @GetMapping("/old-norwegian")
-    fun oldNorwegian(): RevalidationResponse {
-        revalidatorService.revalidateOldNorwegian()
+    fun oldNorwegian(
+        @RequestParam("start") start: Int? = null,
+        @RequestParam("end") end: Int? = null
+    ): RevalidationResponse {
+        revalidatorService.revalidateOldNorwegian(start, end)
         return RevalidationResponse(mapOf(DictionaryType.OLD_NORWEGIAN to true))
     }
 

--- a/src/main/kotlin/io/github/stscoundrel/revalidator/revalidators/Revalidator.kt
+++ b/src/main/kotlin/io/github/stscoundrel/revalidator/revalidators/Revalidator.kt
@@ -30,21 +30,22 @@ class Revalidator {
         println("${dictionary.name}: $message")
     }
 
-    fun revalidate() {
-        var start = 0
+    fun revalidate(start: Int?, end: Int?) {
+        var current = start ?: 0
+        val max = end ?: words
 
         try {
             val retries = mutableListOf<Pair<Int, Int>>()
-            while (start < words) {
-                val end = start + batchSize
-                val statusCode = httpClient.get(getUrl(start, end))
+            while (current < max) {
+                val rangeEnd = current + batchSize
+                val statusCode = httpClient.get(getUrl(current, rangeEnd))
                 if (statusCode == 200) {
-                    log("OK ${statusCode}: Finished words $start - $end")
+                    log("OK ${statusCode}: Finished words $current - $rangeEnd")
                 } else {
-                    log("FAIL ${statusCode}: Failed words $start - $end! Adding to retries...")
-                    retries.add(start to end)
+                    log("FAIL ${statusCode}: Failed words $current - $rangeEnd! Adding to retries...")
+                    retries.add(current to rangeEnd)
                 }
-                start = end
+                current = rangeEnd
             }
 
             if (retries.isNotEmpty()) {

--- a/src/main/kotlin/io/github/stscoundrel/revalidator/service/RevalidatorService.kt
+++ b/src/main/kotlin/io/github/stscoundrel/revalidator/service/RevalidatorService.kt
@@ -23,23 +23,23 @@ class RevalidatorService(val configRepository: RevalidatorConfigRepository, val 
         return revalidators[dictionaryType]!!
     }
 
-    fun revalidateOldNorse() {
+    fun revalidateOldNorse(start: Int? = null, end: Int? = null) {
         val dictionary = getDictionaryRevalidator(DictionaryType.OLD_NORSE)
-        dictionary.revalidate()
+        dictionary.revalidate(start, end)
     }
 
-    fun revalidateOldIcelandic() {
+    fun revalidateOldIcelandic(start: Int? = null, end: Int? = null) {
         val dictionary = getDictionaryRevalidator(DictionaryType.OLD_ICELANDIC)
-        dictionary.revalidate()
+        dictionary.revalidate(start, end)
     }
 
-    fun revalidateOldSwedish() {
+    fun revalidateOldSwedish(start: Int? = null, end: Int? = null) {
         val dictionary = getDictionaryRevalidator(DictionaryType.OLD_SWEDISH)
-        dictionary.revalidate()
+        dictionary.revalidate(start, end)
     }
 
-    fun revalidateOldNorwegian() {
+    fun revalidateOldNorwegian(start: Int? = null, end: Int? = null) {
         val dictionary = getDictionaryRevalidator(DictionaryType.OLD_NORWEGIAN)
-        dictionary.revalidate()
+        dictionary.revalidate(start, end)
     }
 }


### PR DESCRIPTION
Allows revalidation of custom ranges. Mostly for cases of catastrophic failure in middle of longer revalidation.

Closes #33